### PR TITLE
Use two spaces for tabs in the editor.

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -25,6 +25,7 @@ $(function() {
 
         session.setMode(lang);
         session.setValue($('#' + ta_name).val());
+        session.setOptions({ tabSize: 2, useSoftTabs: true });
 
         session.on('change', _.debounce(function() {
 


### PR DESCRIPTION
Just a suggestion. You used two spaces in all the examples, as far as I can see.