### PR TITLE
Adding a button to publish code as an annonymous gist

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -30,11 +30,18 @@ body {
   vertical-align: middle;
   margin-bottom: 5px;
 }
-#showjs, #compile {
+#showjs, #auto_compile {
   margin-left: 10px;
+  margin-right: 0px;
 }
-#auto_compile {
-  margin-left: 10px;
+#showjs_label, #compile_label {
+  margin-left: 0px;
+}
+#view_mode label, #showjs_label, #compile_label, #gist_save {
+  cursor: pointer;
+}
+#view_mode label:hover, #showjs:hover, #showjs_label:hover, #auto_compile:hover, #compile_label:hover, #gist_save:hover {
+  background-color: black;
 }
 
 #view_mode {
@@ -42,13 +49,9 @@ body {
   margin: 0px;
   padding: 0px;
 }
-#view_mode label {
-  cursor: pointer;
+#view_mode label, #showjs_label, #compile_label, #gist_save {
   display: inline-block;
-  padding-top: 5px;
-  padding-bottom: 5px;
-  padding-left: 10px;
-  padding-right: 10px;
+  padding: 5px 10px;
   text-align: center;
 }
 #view_mode li {
@@ -80,6 +83,19 @@ body {
   flex: 1;
   margin-top: 0px;
 
+}
+
+#gists {
+  display: inline-block;
+  margin: 0px;
+  padding: 0px;
+}
+#gists li {
+  display: inline-block;
+  padding: 0px;
+  padding-left: 0px;
+  margin: 0px;
+  border: 0px;
 }
 
 #column1, #column2 {

--- a/index.html
+++ b/index.html
@@ -20,26 +20,34 @@
         <ul id="view_mode">
           <li>
             <input type="radio" name="view_mode" value="sidebyside" id="view_sidebyside" checked="true">
-            <label for="view_sidebyside">Side by side</label>
+            <label for="view_sidebyside" title="Show the code and output side by side">Side by side</label>
           </li>
           <li>
             <input type="radio" name="view_mode" value="code" id="view_code">
-            <label for="view_code">Code</label>
+            <label for="view_code" title="Show only the code">Code</label>
           </li>
           <li>
             <input type="radio" name="view_mode" value="output" id="view_output">
-            <label for="view_output">Output</label>
+            <label for="view_output" title="Show only the output">Output</label>
           </li>
         </ul>
+
+        <ul id="gists">
+          <li>
+            <label id="gist_save" name="save_gist" title="Save file as a Gist">Share</label>
+          </li>
+        </ul>
+
         <span class="nowrap">
-          <input id="auto_compile" name="auto_compile" value="auto_compile" type="checkbox" checked="true">
-          <label id="compile_label">Compile</label>
+          <input id="auto_compile" name="auto_compile" title="Toggle auto-compliation of the file on code changes" value="auto_compile" type="checkbox" checked="true">
+          <label id="compile_label" title="Compile file">Compile</label>
         </span>
 
         <span class="nowrap">
-          <input id="showjs" name="showjs" value="showjs" type="checkbox">
-          <label id="showjs_label" for="showjs">Show JS</label>
+          <input id="showjs" name="showjs" title="Show resulting JavaScript code instead of output" value="showjs" type="checkbox">
+          <label id="showjs_label" for="showjs" title="Show resulting JavaScript code instead of output">Show JS</label>
         </span>
+
       </div>
       <div id="editor_view">
         <div id="column1">


### PR DESCRIPTION
Adds a 'Share' button at the top right of the screen.

Pressing on it will trigger a confirm message. after that it will:
- Create an annonymous gist via github
- Refresh the page with the `gist` query parameter updated to the newly created gist
or it will fail and `alert` the user and will print the response object in console.

A few more changes:

- Tooltips for buttons
- pointer cursor for buttons
- Don't load session if `gist` query parameter is present (does that make sense?)

[Viewable here](https://soupi.github.io/trypurescript).