### PR TITLE
img max-width for slides.css

### DIFF
--- a/css/slides.css
+++ b/css/slides.css
@@ -23,6 +23,10 @@ h3 {
   font-size: 1.5em
 }
 
+img {
+  max-width: 100%;
+}
+
 .flexbox {
   margin: 5px;
 


### PR DESCRIPTION
Should fix image size problems is try-purescript (especially on mobile)

- [Current try-purs preview](http://try.purescript.org/?gist=639c65f69c38b043dabf29f27266bfe9&backend=slides&view=output)
- [After fix preview](https://soupi.github.io/trypurescript/?gist=639c65f69c38b043dabf29f27266bfe9&backend=slides&view=output)

if you don't see the difference try to shrink your window.