### PR TITLE
Type search

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,7 @@ flags: {}
 packages:
 - '.'
 extra-deps:
-- purescript-0.10.4
-- bower-json-0.8.0
+- purescript-0.10.5
+- bower-json-1.0.0.1
 - language-javascript-0.6.0.9
 - parsec-3.1.11

--- a/trypurescript.cabal
+++ b/trypurescript.cabal
@@ -1,5 +1,5 @@
 name: trypurescript
-version: 0.10.4
+version: 0.10.5
 cabal-version: >=1.8
 build-type: Simple
 license: BSD3
@@ -20,11 +20,12 @@ executable trypurescript
                    filepath -any,
                    Glob -any,
                    scotty -any,
-                   purescript ==0.10.4,
+                   purescript ==0.10.5,
                    containers -any,
                    http-types >= 0.8.5,
                    transformers ==0.4.*,
                    mtl ==2.2.1,
+                   parsec,
                    text -any,
                    time -any
     hs-source-dirs: server


### PR DESCRIPTION
This is a work-in-progress.

The idea is to expose a `/search` endpoint which Pursuit can use to implement type search using the externs held by the Try PureScript process.

I added this here instead of in a separate service since we already have the data in memory, and it seems wasteful to load it all twice on the server when we have limited resources.

The main issue is that replacing type variables with unknowns generally yields too many results. We could use skolems instead, which works better in some cases, but in other cases it gives too few results, since the generalization step doesn't work in the solver.

Another thing I would like to try is to resolve unqualified constructors by looking up any matching constructors in the `Environment`.