### PR TITLE
busy wait on body for iframe to load

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -276,18 +276,17 @@ $(function() {
     script.appendChild(iframe.createTextNode(scripts));
 
     $('iframe').ready(function() {
+      var checkExists = setInterval(function() {
+        var body = iframe.getElementsByTagName('body')[0];
+        if (body) {
+          body.onclick = function() {
+            hideMenus();
+          };
+          body.appendChild(script);
+          clearInterval(checkExists);
+        }
+      }, 100);
 
-      var body = iframe.getElementsByTagName('body')[0];
-
-      body.onclick = function() {
-        hideMenus();
-      };
-
-      if (body) {
-        body.appendChild(script);
-      } else {
-        console.log("<body> element is missing!");
-      }
     });
 
   };


### PR DESCRIPTION
In the previous fix of `.load()` -> `.ready()` it appear that now `iframe` is `ready` before body is ready. this is ok for most cases but not for mathbox which has an extra js dep. and at the point of `var body` the `iframe` is not ready yet.

This fixes this issue by busy waiting on `body` to be ready. It's a bit ugly, but i haven't found a better solution from googling this issue.