### PR TITLE
Updates for 0.11

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,8 @@ flags: {}
 packages:
 - '.'
 extra-deps:
-- purescript-0.10.5
+- purescript-0.11.1
 - bower-json-1.0.0.1
 - language-javascript-0.6.0.9
+- optparse-applicative-0.13.2.0
 - parsec-3.1.11

--- a/staging/core/psc-package.json
+++ b/staging/core/psc-package.json
@@ -1,6 +1,6 @@
 {
     "name": "core",
-    "set": "psc-0.10.2",
+    "set": "psc-0.11.1",
     "source": "https://github.com/purescript/package-sets.git",
     "depends": [
         "arrays",
@@ -45,6 +45,7 @@
         "tailrec",
         "transformers",
         "tuples",
+        "typelevel-prelude",
         "unfoldable",
         "validation"
     ]

--- a/trypurescript.cabal
+++ b/trypurescript.cabal
@@ -1,5 +1,5 @@
 name: trypurescript
-version: 0.10.5
+version: 0.11.1
 cabal-version: >=1.8
 build-type: Simple
 license: BSD3
@@ -20,7 +20,7 @@ executable trypurescript
                    filepath -any,
                    Glob -any,
                    scotty -any,
-                   purescript ==0.10.5,
+                   purescript ==0.11.1,
                    containers -any,
                    http-types >= 0.8.5,
                    transformers ==0.4.*,


### PR DESCRIPTION
My plan is to deploy this over the weekend. I will start by disabling all "Try X" services, and I'll turn them back on as soon as the necessary libraries are updated and I have a working `psc-package.json` or `bower.json` for each one.

So there's no real rush, since the core "Try PureScript" will be working, but the other services will be offline initially.

cc @sharkdp @soupi @rintcius 