### PR TITLE
adding a link to gist under view mode

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -98,6 +98,13 @@ body {
   border-left: solid 1px #fff;
   border-right: solid 1px #fff;
 }
+#view_mode a {
+  display:block;
+  color: white;
+}
+#view_mode a:visited {
+  color: white;
+}
 
 #view_mode input[type="radio"]:checked + label, #backend input[type="radio"]:checked + label {
   color: #c4953a;

--- a/index.html
+++ b/index.html
@@ -44,6 +44,11 @@
               <input type="radio" name="view_mode" value="output" id="view_output">
               <label for="view_output" title="Show only the output">Output</label>
             </li>
+            <li id="view_gist_li">
+              <a id="view_gist" target="trypurs_gist">
+                <label title="Open the original gist in a new window">Gist</label>
+              </a>
+            </li>
           </ul>
 
           <label id="backend_label" title="Select a Backend">Backend</label>

--- a/js/index.js
+++ b/js/index.js
@@ -121,6 +121,12 @@ $(function() {
       $('input:checkbox[name=auto_compile]').prop('checked', auto_compile === "true");
     }
 
+    var gist = $.QueryString["gist"];
+    if (gist) {
+      $('#view_gist').attr('href', 'https://gist.github.com/' + gist);
+    } else {
+      $('#view_gist_li').hide();
+    }
 
     $('input[name=backend_inputs]').change(function(e) {
       var backend = getBackend($(this).filter(':checked').val());


### PR DESCRIPTION
This commit adds a link to a gist on github (useful for mobile users who just want to read the code) as suggested [here](https://twitter.com/bkase_/status/879030876377665536).

- When a link to gist is available it will add a 'Gist' link under 'View Mode' menu ([Preview](https://soupi.github.io/trypurescript/))
- When  a gist is not available it will not show this option at all ([Preview](https://soupi.github.io/trypurescript/?gist=3f735aa2a652af592101))