### PR TITLE
setQueryStrings should replace existing parameters

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -5000,7 +5000,7 @@ var PS = {};
   var setQueryStrings = function (ss) {
       return function __do() {
           var v = getQueryParams();
-          return Control_Monad_Eff_Uncurried.runEffFn1($foreign.setQueryParameters)(Data_StrMap.union(v)(ss))();
+          return Control_Monad_Eff_Uncurried.runEffFn1($foreign.setQueryParameters)(Data_StrMap.union(ss)(v))();
       };
   };
   var setQueryString = function (k) {

--- a/src/Try/QueryString.purs
+++ b/src/Try/QueryString.purs
@@ -52,4 +52,4 @@ setQueryString k v = setQueryStrings (StrMap.singleton k v)
 setQueryStrings :: forall eff. StrMap.StrMap String -> Eff (dom :: DOM | eff) Unit
 setQueryStrings ss = do
   params <- getQueryParams
-  runEffFn1 setQueryParameters (StrMap.union params ss)
+  runEffFn1 setQueryParameters (StrMap.union ss params)


### PR DESCRIPTION
`union` is left-biased: https://pursuit.purescript.org/packages/purescript-maps/3.5.0/docs/Data.StrMap#v:union

This should fix the issue where saving a gist would not update the url if the url already had a gist parameter. But I haven't tested it 😁 