### PR TITLE
Match stack resolver from pursuit and purescript-0.11.7

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,4 @@
-resolver: lts-8.5
-flags: {}
+resolver: nightly-2017-09-10
 packages:
 - '.'
 extra-deps:

--- a/trypurescript.cabal
+++ b/trypurescript.cabal
@@ -13,21 +13,21 @@ author: Phil Freeman
 data-dir: ""
 
 executable trypurescript
-    build-depends: base ==4.*,
-                   aeson -any,
-                   bytestring >=0.10.0.2 && <0.11,
-                   directory -any,
-                   filepath -any,
-                   Glob -any,
-                   scotty -any,
-                   purescript ==0.11.7,
-                   containers -any,
-                   http-types >= 0.8.5,
-                   transformers ==0.5.*,
-                   mtl ==2.2.1,
+    build-depends: base,
+                   aeson,
+                   bytestring,
+                   directory,
+                   filepath,
+                   Glob,
+                   scotty,
+                   purescript,
+                   containers,
+                   http-types,
+                   transformers,
+                   mtl,
                    parsec,
-                   text -any,
-                   time -any
+                   text,
+                   time
     hs-source-dirs: server
     main-is: Main.hs
     buildable: True


### PR DESCRIPTION
In the process of nixify-ing builds of pursuit and trypurescript I noticed this project was using a different stack resolver than pursuit and the release version of purescript-0.11.7.  This PR simply aligns this project's stack resolver with the others (in the spirit of having common tooling across the infrastructure).

Note: I removed the package version constraints from the cabal file - I felt they were unneeded as stack and its resolver provide specific versions of packages.