### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,11 @@ before_install:
   - export PATH=$HOME/.local/bin:$PATH
   - curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
-
-install:
-  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
-  - travis_wait stack --no-terminal -j1 --install-ghc build --only-dependencies
-  
 script:
-  - travis_wait stack --no-terminal -j1 build
+  # Set a timeout of 35 minutes. We could use travis_wait here, but travis_wait
+  # doesn't produce any output until the command finishes, and also doesn't
+  # always show all of the command's output.
+  - timeout 35m stack --no-terminal -j1 --install-ghc build
 
 notifications:
   email: true


### PR DESCRIPTION
- use `timeout` rather than `travis_wait`, as I've found `timeout` to be more reliable
- increase timeout from 20 minutes to 35 minutes
- install dependencies in the `script` step so that the cache can still be saved if installing dependencies doesn't complete in time (Travis won't save a cache if the build fails in the `install` step)