### PR TITLE
Merge changes from #128

### DIFF
--- a/client/frame.html
+++ b/client/frame.html
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <title>Try PureScript!</title>
+  <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+  <meta content="utf-8" http-equiv="encoding">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="js/frame.js"></script>
+</head>
+<body>
+<main id="main"></main>
+</body>
+</html>

--- a/client/index.html
+++ b/client/index.html
@@ -47,36 +47,6 @@
               </a>
             </li>
           </ul>
-        </li><li class="menu-item menu-dropdown no-mobile">
-          <label title="Select a Backend">Backend</label>
-          <ul id="backend">
-            <li>
-              <input type="radio" name="backend_inputs" value="core" id="backend_core" checked="true">
-              <label for="backend_core" title="Use the core libraries backend">Core</label>
-            </li>
-            <!--
-            <li>
-              <input type="radio" name="backend_inputs" value="thermite" id="backend_thermite">
-              <label for="backend_thermite" title="Use the try-thermite backend">Thermite</label>
-            </li>
-            <li>
-              <input type="radio" name="backend_inputs" value="slides" id="backend_slides">
-              <label for="backend_slides" title="Use the try-slides backend">Slides</label>
-            </li>
-            <li>
-              <input type="radio" name="backend_inputs" value="flare" id="backend_flare">
-              <label for="backend_flare" title="Use the try-flare backend">Flare</label>
-            </li>
-            <li>
-              <input type="radio" name="backend_inputs" value="mathbox" id="backend_mathbox">
-              <label for="backend_mathbox" title="Use the try-mathbox backend">Mathbox</label>
-            </li>
-            <li>
-              <input type="radio" name="backend_inputs" value="behaviors" id="backend_behaviors">
-              <label for="backend_behaviors" title="Use the try-behaviors backend">Behaviors</label>
-            </li>
-            -->
-          </ul>
         </li><li class="menu-item view_gist_li mobile-only">
           <a class="view_gist" target="trypurs_gist">
             <label title="Open the original gist in a new window">View Gist</label>
@@ -188,30 +158,31 @@
       })(marker));
     }
 
-    function setupIFrame($ctr, html, js) {
-      var $iframe = $('<iframe id="output-iframe">');
+    function setupIFrame($ctr, data) {
+      var $iframe = $('<iframe sandbox="allow-scripts" id="output-iframe" src="frame.html">');
 
       $ctr
         .empty()
         .append($iframe);
 
-      var iframe = $iframe.get(0).contentWindow.document;
-      iframe.open();
-      iframe.write(html);
-      iframe.close();
+      var tries = 0;
+      var sendSources = setInterval(function() {
+        // Stop after 10 seconds
+        if (tries >= 100) {
+          return clearInterval(sendSources);
+        }
+        tries++;
+        var iframe = $iframe.get(0).contentWindow;
+        if (iframe) {
+          iframe.postMessage(data, "*");
+        } else {
+          console.warn("Frame is not available");
+        }
+      }, 100);
 
-      var script = iframe.createElement('script');
-      script.appendChild(iframe.createTextNode(js));
-
-      $iframe.ready(function() {
-        var checkExists = setInterval(function() {
-          var body = iframe.getElementsByTagName('body')[0];
-          if (body) {
-            body.appendChild(script);
-            clearInterval(checkExists);
-          }
-        }, 100);
-      });
+      window.addEventListener("message", function() {
+        clearInterval(sendSources);
+      }, { once: true });
 
       return $iframe;
     }

--- a/client/js/frame.js
+++ b/client/js/frame.js
@@ -1,0 +1,39 @@
+(function() {
+  function evalSources(sources) {
+    var modules = {};
+    function dirname(str) {
+      var ix = str.lastIndexOf("/");
+      return ix < 0 ? "" : str.slice(0, ix);
+    }
+    function resolvePath(a, b) {
+      if (b[0] === "." && b[1] === "/") {
+        return dirname(a) + b.slice(1);
+      }
+      if (b[0] === "." && b[1] === "." && b[2] === "/") {
+        return dirname(dirname(a)) + b.slice(2);
+      }
+      return b;
+    }
+    return function load(name) {
+      if (modules[name]) {
+        return modules[name].exports;
+      }
+      function require(path) {
+        return load(resolvePath(name, path));
+      }
+      var module = modules[name] = { exports: {} };
+      new Function("module", "exports", "require", sources[name])(module, module.exports, require);
+      return module.exports;
+    };
+  }
+
+  document.addEventListener("DOMContentLoaded", function() {
+    window.addEventListener("message", function(event) {
+      event.source.postMessage("trypurescript", "*");
+      var file = evalSources(event.data)("<file>");
+      if (file.main && typeof file.main === "function") {
+        file.main();
+      }
+    }, { once: true });
+  }, { once: true });
+})();

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "clean": "rimraf output && rimraf .pulp-cache",
     "build": "pulp build -- --censor-lib --strict",
-    "bundle": "pulp build -O --to js/index.js && open index.html"
+    "bundle": "pulp build -O --to js/index.js"
   },
   "devDependencies": {
     "pulp": "^13.0.0",

--- a/client/src/Try/API.purs
+++ b/client/src/Try/API.purs
@@ -7,10 +7,8 @@ module Try.API
   , SuccessResult(..)
   , FailedResult(..)
   , CompileResult(..)
-  , Backend(..)
-  , BackendConfig(..)
-  , getBackendConfig
-  , getBackendConfigFromString
+  , get
+  , compile
   ) where
 
 import Prelude
@@ -19,23 +17,16 @@ import Control.Alt ((<|>))
 import Control.Monad.Cont.Trans (ContT(ContT))
 import Control.Monad.Except (runExcept)
 import Control.Monad.Except.Trans (ExceptT(ExceptT))
-import Control.Parallel (parTraverse)
-import Data.Array (fold, intercalate)
 import Data.Either (Either(..))
 import Data.Generic.Rep (class Generic)
 import Data.List.NonEmpty (NonEmptyList)
 import Data.Maybe (Maybe)
-import Data.String.Regex (replace)
-import Data.String.Regex.Flags (global)
-import Data.String.Regex.Unsafe (unsafeRegex)
 import Effect (Effect)
 import Effect.Uncurried (EffectFn1, EffectFn3, EffectFn4, mkEffectFn1, runEffectFn3, runEffectFn4)
 import Foreign (Foreign, ForeignError)
 import Foreign.Class (class Decode, decode)
 import Foreign.Generic (defaultOptions, genericDecode)
 import Foreign.Generic.Class (Options, SumEncoding(..))
-import Partial.Unsafe (unsafePartial)
-import Try.Types (JS(JS))
 
 decodingOptions :: Options
 decodingOptions = defaultOptions { unwrapSingleConstructors = true }
@@ -143,35 +134,6 @@ foreign import get_
 get :: String -> ExceptT String (ContT Unit Effect) String
 get uri = ExceptT (ContT \k -> runEffectFn3 get_ uri (mkEffectFn1 (k <<< Right)) (mkEffectFn1 (k <<< Left)))
 
--- | Get the default bundle
-getDefaultBundle
-  :: String
-  -> ExceptT String (ContT Unit Effect) JS
-getDefaultBundle endpoint = JS <$> get (endpoint <> "/bundle")
-
--- | Get the JS bundle for the Thermite backend, which includes additional dependencies
-getThermiteBundle
-  :: String
-  -> ExceptT String (ContT Unit Effect) JS
-getThermiteBundle endpoint =
-  let getAll = parTraverse get
-        [ "js/console.js"
-        , "js/react.min.js"
-        , "js/react-dom.min.js"
-        , endpoint <> "/bundle"
-        ]
-
-      onComplete :: Partial
-                 => Array String
-                 -> JS
-      onComplete [consoleScript, react, react_dom, bundle] =
-        let replaced = bundle
-                         # replace (unsafeRegex """require\("react"\)""" global) "window.React"
-                         # replace (unsafeRegex """require\("react-dom"\)""" global) "window.ReactDOM"
-                         # replace (unsafeRegex """require\("react-dom\/server"\)""" global) "window.ReactDOM"
-        in JS (intercalate "\n" [consoleScript, react, react_dom, replaced])
-  in unsafePartial onComplete <$> getAll
-
 -- | POST the specified code to the Try PureScript API, and wait for
 -- | a response.
 foreign import compile_
@@ -189,102 +151,3 @@ compile
   -> ExceptT String (ContT Unit Effect)
        (Either (NonEmptyList ForeignError) CompileResult)
 compile endpoint code = ExceptT (ContT \k -> runEffectFn4 compile_ endpoint code (mkEffectFn1 (k <<< Right <<< runExcept <<< decode)) (mkEffectFn1 (k <<< Left)))
-
-newtype BackendConfig = BackendConfig
-  { backend       :: String
-  , mainGist      :: String
-  , extra_styling :: String
-  , extra_body    :: String
-  , compile       :: String
-                  -> ExceptT String (ContT Unit Effect)
-                       (Either (NonEmptyList ForeignError) CompileResult)
-  , getBundle     :: ExceptT String (ContT Unit Effect) JS
-  }
-
-data Backend
-  = Core
-  | Thermite
-  | Slides
-  | Mathbox
-  | Behaviors
-  | Flare
-
-backendFromString :: Partial => String -> Backend
-backendFromString "core"      = Core
-backendFromString "thermite"  = Thermite
-backendFromString "slides"    = Slides
-backendFromString "mathbox"   = Mathbox
-backendFromString "behaviors" = Behaviors
-backendFromString "flare"     = Flare
-
-backendToString :: Backend -> String
-backendToString Core      = "core"
-backendToString Thermite  = "thermite"
-backendToString Slides    = "slides"
-backendToString Mathbox   = "mathbox"
-backendToString Behaviors = "behaviors"
-backendToString Flare     = "flare"
-
-derive instance eqBackend :: Eq Backend
-derive instance ordBackend :: Ord Backend
-
-getBackendConfig :: Backend -> BackendConfig
-getBackendConfig Core = BackendConfig
-  { backend: "core"
-  , mainGist: "e1d317102aad40207309d8873e301273"
-  , extra_styling: ""
-  , extra_body: ""
-  , compile: compile "https://compile.purescript.org/try"
-  , getBundle: getDefaultBundle "https://compile.purescript.org/try"
-  }
-getBackendConfig Thermite = BackendConfig
-  { backend: "thermite"
-  , mainGist: "85383bb058471109cfef379bbb6bc11c"
-  , extra_styling: """<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">"""
-  , extra_body: """<div id="app"></div>"""
-  , compile: compile "https://compile.purescript.org/thermite"
-  , getBundle: getThermiteBundle "https://compile.purescript.org/thermite"
-  }
-getBackendConfig Slides = BackendConfig
-  { backend: "slides"
-  , mainGist: "c62b5778a6a5f2bcd32dd97b294c068a"
-  , extra_styling: """<link rel="stylesheet" href="css/slides.css">"""
-  , extra_body: """<div id="main"></div>"""
-  , compile: compile "https://compile.purescript.org/slides"
-  , getBundle: getDefaultBundle "https://compile.purescript.org/slides"
-  }
-getBackendConfig Mathbox = BackendConfig
-  { backend: "mathbox"
-  , mainGist: "81f8bb3261b9c819d677de2ea54a4d2e"
-  , extra_styling: fold
-      [ """<script src="js/mathbox-bundle.js"></script>"""
-      , """<link rel="stylesheet" href="css/mathbox.css">"""
-      ]
-  , extra_body: ""
-  , compile: compile "https://compile.purescript.org/purescript-mathbox"
-  , getBundle: getDefaultBundle "https://compile.purescript.org/purescript-mathbox"
-  }
-getBackendConfig Behaviors = BackendConfig
-  { backend: "behaviors"
-  , mainGist: "ff1e87f0872d2d891e77d209d8f7706d"
-  , extra_styling: ""
-  , extra_body: """<canvas id="canvas" width="800" height="600"></canvas>"""
-  , compile: compile "https://compile.purescript.org/behaviors"
-  , getBundle: getDefaultBundle "https://compile.purescript.org/behaviors"
-  }
-getBackendConfig Flare = BackendConfig
-  { backend: "flare"
-  , mainGist: "4f54d6dd213caa54d736ead597e17fee"
-  , extra_styling: """<link rel="stylesheet" href="css/flare.css">"""
-  , extra_body: fold
-      [ """<div id="controls"></div>"""
-      , """<div id="output"></div>"""
-      , """<div id="tests"></div>"""
-      , """<canvas id="canvas" width="800" height="600"></canvas>"""
-      ]
-  , compile: compile "https://compile.purescript.org/flare"
-  , getBundle: getDefaultBundle "https://compile.purescript.org/flare"
-  }
-
-getBackendConfigFromString :: String -> BackendConfig
-getBackendConfigFromString s = getBackendConfig (unsafePartial backendFromString s)

--- a/client/src/Try/Config.purs
+++ b/client/src/Try/Config.purs
@@ -1,0 +1,10 @@
+module Try.Config where
+
+loaderUrl :: String
+loaderUrl = "js/output"
+
+compileUrl :: String
+compileUrl = "http://localhost:8081"
+
+mainGist :: String
+mainGist = "b57a766d417e109785540d584266fc33"

--- a/client/src/Try/Config.purs
+++ b/client/src/Try/Config.purs
@@ -7,4 +7,4 @@ compileUrl :: String
 compileUrl = "http://localhost:8081"
 
 mainGist :: String
-mainGist = "b57a766d417e109785540d584266fc33"
+mainGist = "e1d317102aad40207309d8873e301273"

--- a/client/src/Try/Loader.purs
+++ b/client/src/Try/Loader.purs
@@ -1,0 +1,135 @@
+module Try.Loader
+  ( Loader
+  , makeLoader
+  , runLoader
+  ) where
+
+import Prelude
+
+import Control.Bind (bindFlipped)
+import Control.Monad.Cont (ContT)
+import Control.Monad.Except (ExceptT)
+import Control.Parallel (parTraverse)
+import Data.Array as Array
+import Data.Array.NonEmpty as NonEmpty
+import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Newtype (unwrap)
+import Data.String (Pattern(..))
+import Data.String as String
+import Data.String.Regex (Regex)
+import Data.String.Regex as Regex
+import Data.String.Regex.Flags (noFlags)
+import Data.String.Regex.Unsafe (unsafeRegex)
+import Data.Tuple (Tuple(..))
+import Effect (Effect)
+import Effect.Class (liftEffect)
+import Effect.Ref (Ref)
+import Effect.Ref as Ref
+import Effect.Unsafe (unsafePerformEffect)
+import Foreign.Object (Object)
+import Foreign.Object as Object
+import Try.API as API
+import Try.Shim (shims)
+import Try.Types (JS(..))
+
+type Module =
+  { name :: String
+  , path :: Maybe String
+  , deps :: Array Dependency
+  , src :: JS
+  }
+
+type Dependency =
+  { name :: String
+  , path :: Maybe String
+  }
+
+requireRegex :: Regex
+requireRegex = unsafeRegex """^var\s+\S+\s*=\s*require\(["']([^"']*)["']\)""" noFlags
+
+dirname :: String -> String
+dirname path = fromMaybe "" do
+  ix <- String.lastIndexOf (Pattern "/") path
+  pure $ String.take ix path
+
+resolvePath :: String -> String -> Maybe String
+resolvePath a b
+  | String.take 2 b == "./"  = Just $ dirname a <> String.drop 1 b
+  | String.take 3 b == "../" = Just $ dirname (dirname a) <> String.drop 2 b
+  | otherwise = Nothing
+
+parseDeps :: String -> JS -> Array Dependency
+parseDeps current = Array.mapMaybe go <<< String.split (Pattern "\n") <<< unwrap
+  where
+  go :: String -> Maybe Dependency
+  go line = do
+    match <- Regex.match requireRegex line
+    requirePath <- join $ NonEmpty.index match 1
+    pure $ case resolvePath current requirePath of
+      Just path ->
+        { name: path
+        , path: String.stripPrefix (Pattern "/") path
+        }
+      _ ->
+        { name: requirePath
+        , path: Nothing
+        }
+
+newtype Loader = Loader (JS -> ExceptT String (ContT Unit Effect) (Object JS))
+
+runLoader :: Loader -> JS -> ExceptT String (ContT Unit Effect) (Object JS)
+runLoader (Loader k) = k
+
+makeLoader :: String -> Loader
+makeLoader rootPath = Loader (go Object.empty <<< parseDeps "<file>")
+  where
+  moduleCache :: Ref (Object Module)
+  moduleCache = unsafePerformEffect (Ref.new Object.empty)
+
+  putModule :: String -> Module -> Effect Unit
+  putModule a b = Ref.modify_ (Object.insert a b) moduleCache
+
+  getModule :: String -> Effect (Maybe Module)
+  getModule a = Object.lookup a <$> Ref.read moduleCache
+
+  load :: Dependency -> ExceptT String (ContT Unit Effect) Module
+  load { name, path } = do
+    cached <- liftEffect $ getModule name
+    case cached of
+      Just mod -> pure mod
+      Nothing -> do
+        mod <-
+          case path of
+            Just path' -> do
+              srcStr <- API.get (rootPath <> "/" <> path')
+              let src = JS $ srcStr <> "\n//@ sourceURL=" <> path'
+              pure { name, path, deps: parseDeps name src, src }
+            Nothing -> case Object.lookup name shims of
+              Just shim -> do
+                srcStr <- API.get shim.url
+                let
+                  src = JS $ srcStr <> "\n//@ sourceURL=" <> shim.url
+                  deps = { name: _, path: Nothing } <$> shim.deps
+                pure { name, path, deps, src }
+              Nothing ->
+                pure { name, path, deps: [], src: ffiDep name }
+        liftEffect $ putModule name mod
+        pure mod
+
+  go :: Object JS -> Array Dependency -> ExceptT String (ContT Unit Effect) (Object JS)
+  go ms []   = pure ms
+  go ms deps = do
+    modules <- parTraverse load deps
+    let
+      ms' =
+        modules
+          # map (\{ name, src } -> Tuple name src)
+          # Object.fromFoldable
+          # Object.union ms
+    modules
+      # bindFlipped _.deps
+      # Array.nubBy (comparing _.name)
+      # go ms'
+
+ffiDep :: String -> JS
+ffiDep name = JS $ "throw new Error('FFI dependency not provided: " <> name <> "');"

--- a/client/src/Try/Session.purs
+++ b/client/src/Try/Session.purs
@@ -30,22 +30,22 @@ randomGuid =
 
 foreign import storeSession_
   :: EffectFn2 String
-               { code :: String, backend :: String }
+               { code :: String }
                Unit
 
 -- | Store the current session state in local storage
 storeSession
   :: String
-  -> { code :: String, backend :: String }
+  -> { code :: String }
   -> Effect Unit
 storeSession sessionId values = runEffectFn2 storeSession_ sessionId values
 
 foreign import tryRetrieveSession_
   :: EffectFn1 String
-               (Nullable { code :: String, backend :: String })
+               (Nullable { code :: String })
 
 -- | Retrieve the session state from local storage
-tryRetrieveSession :: String -> Effect (Maybe { code :: String, backend :: String })
+tryRetrieveSession :: String -> Effect (Maybe { code :: String })
 tryRetrieveSession sessionId = toMaybe <$> runEffectFn1 tryRetrieveSession_ sessionId
 
 -- | Look up the session by ID, or create a new session ID.

--- a/client/src/Try/Shim.purs
+++ b/client/src/Try/Shim.purs
@@ -1,0 +1,27 @@
+module Try.Shim where
+
+import Data.Tuple (Tuple(..))
+import Foreign.Object (Object)
+import Foreign.Object as Object
+
+type Shim =
+  { url :: String
+  , deps :: Array String
+  }
+
+shims :: Object Shim
+shims = Object.fromFoldable
+  [ Tuple "react"
+      { url: "https://unpkg.com/react@16.6.3/umd/react.development.js"
+      , deps: []
+      }
+  , Tuple "react-dom"
+      { url: "https://unpkg.com/react-dom@16.6.3/umd/react-dom.development.js"
+      , deps: [ "react" ]
+      }
+  , Tuple "react-dom/server"
+      { url: "https://unpkg.com/react-dom@16.6.3/umd/react-dom-server.browser.development.js"
+      , deps: [ "react" ]
+      }
+  ]
+

--- a/client/src/Try/Types.purs
+++ b/client/src/Try/Types.purs
@@ -3,7 +3,10 @@ module Try.Types
   ) where
 
 import Data.Newtype (class Newtype)
+import Foreign.Class (class Encode)
 
 newtype JS = JS String
 
 derive instance newtypeJS :: Newtype JS _
+
+derive newtype instance encodeJS :: Encode JS


### PR DESCRIPTION
I merged the changes from #128 into master and updated `Try.Config.mainGist` to point to my updated fork.

In order to load the modules, it's necessary to copy the contents of `staging/core/.psci_modules/node_modules/` into `client/js/output/`.

@hdgarrood Again this is the bare minimum. The other backends haven't been removed, no READMEs have been updated, and none of the comments from https://github.com/purescript/trypurescript/pull/135#pullrequestreview-363054421 have been implemented.

@natefaubion your changes are great! This will likely allow a lot of flexibility for people wanting to run TryPS locally.