### PR TITLE
Enable -threaded and -rtsopts for compile server

### DIFF
--- a/trypurescript.cabal
+++ b/trypurescript.cabal
@@ -32,4 +32,4 @@ executable trypurescript
     main-is: Main.hs
     buildable: True
     other-modules: Main
-    ghc-options: -Werror -O2
+    ghc-options: -Werror -O2 -threaded -rtsopts


### PR DESCRIPTION
-threaded is probably a good idea even if we aren't using multiple
cores, because it allows using OS threading, which I think should be
able to leverage the OS to interleave work more efficiently,
particularly for FFI calls. It also means that if we want to deploy the
compile server on a box with more cores, that's easy to do, we just
tweak the RTS configuration. See
<https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/phases.html?highlight=threaded#ghc-flag--threaded>

Being able to tweak the RTS options (enabled by -rtsopts) has been
absolutely essential for getting Pursuit to run reliably and to keep
memory usage under control, so I'm sure we will want it here too.