### PR TITLE
Fix usage of production config in CI

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -13,7 +13,8 @@ case $COMPONENT in
     cd client
     npm install
     # Use production config, since we want to use these bundles for deploys
-    npm_config_configpath="config/prod/*.purs" npm run build
+    npm config set trypurescript-client:configpath "config/prod/*.purs"
+    npm run build
     ;;
   *)
     echo >&2 "Unrecognised component: $COMPONENT"

--- a/client/package.json
+++ b/client/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "trypurescript-client",
   "private": true,
   "config": {
     "configpath": "config/dev/*.purs"


### PR DESCRIPTION
Right now we are still building the dev config into the deploy bundles,
because I got the config overriding wrong. I've actually tested this
version, at least. See https://docs.npmjs.com/files/package.json#config