### PR TITLE
Allow loading examples from GitHub

### DIFF
--- a/client/config/dev/Try.Config.purs
+++ b/client/config/dev/Try.Config.purs
@@ -6,5 +6,5 @@ loaderUrl = "js/output"
 compileUrl :: String
 compileUrl = "http://localhost:8081"
 
-mainGist :: String
-mainGist = "7ad2b2eef11ac7dcfd14aa1585dd8f69"
+mainGithubExample :: String
+mainGithubExample = "purescript/trypurescript/master/client/examples/Main.purs"

--- a/client/config/prod/Try.Config.purs
+++ b/client/config/prod/Try.Config.purs
@@ -6,5 +6,5 @@ loaderUrl = "https://compile.purescript.org/output"
 compileUrl :: String
 compileUrl = "https://compile.purescript.org"
 
-mainGist :: String
-mainGist = "7ad2b2eef11ac7dcfd14aa1585dd8f69"
+mainGithubExample :: String
+mainGithubExample = "purescript/trypurescript/master/client/examples/Main.purs"

--- a/client/examples/Main.purs
+++ b/client/examples/Main.purs
@@ -1,0 +1,57 @@
+module Main where
+
+import Prelude
+
+import Effect (Effect)
+import Data.Foldable (fold)
+import TryPureScript (h1, h2, p, text, list, indent, link, render, code)
+
+main :: Effect Unit
+main =
+    render $ fold
+      [ h1 (text "Try PureScript!")
+      , p (text "Try out the examples below, or create your own!")
+      , h2 (text "Examples")
+      , list (map fromExample examples)
+      , h2 (text "Share Your Code")
+      , p (text "Code can be loaded from a GitHub Gist. To share code, simply include the Gist ID in the URL as follows:")
+      , indent (p (code (text "  try.purescript.org?gist=gist-id")))
+      , p (fold
+          [ text "The Gist should contain a file named "
+          , code (text "Main.purs")
+          , text " containing your PureScript code."
+          ])
+      ]
+  where
+    fromExample { title, gist } =
+      link ("https://gist.github.com/" <> gist) (text title)
+
+    examples =
+      [ { title: "Algebraic Data Types"
+        , gist: "387999a4467a39744ece236e69a442ec"
+        }
+      , { title: "Loops"
+        , gist: "429eab1e957e807f9feeddbf4f573dd0"
+        }
+      , { title: "Operators"
+        , gist: "8395d2b421a5ca6d1056e301a6e12599"
+        }
+      , { title: "Records"
+        , gist: "170c3ca22f0141ed06a120a12b8243af"
+        }
+      , { title: "Recursion"
+        , gist: "659ae8a085f1cf6e52fed2c35ad93643"
+        }
+      , { title: "Do Notation"
+        , gist: "525cb36c147d3497f652028db1214ec8"
+        }
+      , { title: "Type Classes"
+        , gist: "b04463fd49cd4d7d385941b3b2fa226a"
+        }
+      , { title: "Generic Programming"
+        , gist: "e3b6284959f65ac674d39aa981fcb8fb"
+        }
+      , { title: "QuickCheck"
+        , gist: "69f7f94fe4ff3bd47f4b"
+        }
+      ]

--- a/client/src/Try/Gist.purs
+++ b/client/src/Try/Gist.purs
@@ -5,7 +5,6 @@ module Try.Gist
   , tryLoadFileFromGist
   ) where
 
--- | An abstract data type representing the data we get back from the GitHub API.
 import Prelude
 
 import Control.Monad.Cont.Trans (ContT(..))

--- a/client/src/Try/Github.js
+++ b/client/src/Try/Github.js
@@ -1,0 +1,10 @@
+"use strict";
+
+exports.getRawGithubFile_ = function(id, done, fail) {
+  $.ajax({
+    url: 'https://raw.githubusercontent.com/' + id,
+    dataType: 'text'
+  }).done(done).fail(function(err) {
+    fail("Unable to load file from GitHub");
+  });
+}

--- a/client/src/Try/Github.purs
+++ b/client/src/Try/Github.purs
@@ -1,0 +1,20 @@
+module Try.Github where
+
+import Prelude
+
+import Control.Monad.Cont.Trans (ContT(..))
+import Control.Monad.Except.Trans (ExceptT(..))
+import Data.Either (Either(..))
+import Effect (Effect)
+import Effect.Uncurried (EffectFn1, EffectFn3, EffectFn4, mkEffectFn1, runEffectFn3, runEffectFn4)
+
+-- | Fetch a raw file from a GitHub repo via raw.githubusercontent.com
+foreign import getRawGithubFile_
+  :: EffectFn3 String
+               (EffectFn1 String Unit)
+               (EffectFn1 String Unit)
+               Unit
+
+-- | A wrapper for `getRawGithubFile_` which uses `ContT`.
+getRawGithubFile :: String -> ExceptT String (ContT Unit Effect) String
+getRawGithubFile id_ = ExceptT (ContT \k -> runEffectFn3 getRawGithubFile_ id_ (mkEffectFn1 (k <<< Right)) (mkEffectFn1 (k <<< Left)))

--- a/client/src/Try/Github.purs
+++ b/client/src/Try/Github.purs
@@ -6,7 +6,7 @@ import Control.Monad.Cont.Trans (ContT(..))
 import Control.Monad.Except.Trans (ExceptT(..))
 import Data.Either (Either(..))
 import Effect (Effect)
-import Effect.Uncurried (EffectFn1, EffectFn3, EffectFn4, mkEffectFn1, runEffectFn3, runEffectFn4)
+import Effect.Uncurried (EffectFn1, EffectFn3, mkEffectFn1, runEffectFn3)
 
 -- | Fetch a raw file from a GitHub repo via raw.githubusercontent.com
 foreign import getRawGithubFile_


### PR DESCRIPTION
Resolves #164. This commit implements loading module content from GitHub simply by taking a `github` query string parameter, if present, and tacking that string onto the end of `https://raw.githubusercontent.com/` in order to fetch a PureScript source file from somewhere on GitHub. So for example `try.purescript.org/?github=purescript/trypurescript/master/client/examples/Main.purs` would load the file `client/examples/Main.purs` from the `master` branch in this repo.

I'm hoping that by doing it this way, we will make it easier not only for us to maintain examples, but also for people writing documentation for other projects to create and maintain examples that they can link to and collaborate on, since collaborating on GitHub is much easier than collaborating on Gists.

This is a bit rough at the moment, and I've only added the main example in here, which is why I've marked the pull request as draft. I think at least the following needs to happen before this is mergeable:

* Add handling like we have for gists to allow linking to a github file from within the iframe
* Move the rest of the examples into `client/examples`

but before I go ahead and do that I'd like to just check that the approach seems reasonable.