### PR TITLE
Enable automated SSL certificate renewal

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -3,7 +3,13 @@ server {
     listen 80 default_server;
     listen [::]:80 default_server;
 
-    return 301 https://$host$request_uri;
+    location /.well-known {
+        root /var/www/letsencrypt-webroot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
 }
 
 server {


### PR DESCRIPTION
Amends the nginx config so that nginx will respond to HTTP requests
whose path starts with /.well-known/ with the matching file in
/var/www/letsencrypt-webroot, if any. This allows Let's Encrypt to
verify domain ownership in order to renew certificates automatically.

The `certbot` program is configured by default to renew all certificates
once they are approaching their expiration dates, so with these changes,
all that needs to happen on the server to enable subsequent renewals to
be handled completely automatically is:

- Certbot needs to be told to use the "webroot" plugin for domain
  verification with the appropriate directory when renewing certificates
- Nginx needs to be set up to reload its configuration periodically so
  that newly renewed certificates are picked up.

Note that certbot offers an "nginx" plugin too, but I don't trust it
because it modifies the nginx configuration, and I think it requires
taking the server down for a short time. The "webroot" approach seems
simpler and safer.

I know that this approach works because Pursuit is already using it (see
purescript/pursuit#410), so after this is merged I intend to deploy, SSH
in, and do the above two steps manually.