### PR TITLE
Implement `encode` in PureScript

### DIFF
--- a/staging/src/TryPureScript.js
+++ b/staging/src/TryPureScript.js
@@ -6,14 +6,6 @@ exports.setInnerHTML = function(html) {
   };
 };
 
-exports.encode = function(text) {
-  return text
-    .replace('<', '&lt;')
-    .replace('>', '&gt;')
-    .replace('&', '&amp;')
-    .replace('"', '&quot;');
-};
-
 exports.withConsoleImpl = function(f) {
   return function() {
     var oldLog = console.log;

--- a/staging/src/TryPureScript.purs
+++ b/staging/src/TryPureScript.purs
@@ -20,11 +20,18 @@ module TryPureScript
 import Prelude
 import Data.Foldable (class Foldable, foldMap)
 import Data.String (joinWith)
+import Data.String.Common (replace)
+import Data.String.Pattern (Pattern(..), Replacement(..))
 import Effect (Effect)
 
 foreign import setInnerHTML :: String -> Effect Unit
 
-foreign import encode :: String -> String
+encode :: String -> String
+encode =
+  replace (Pattern "<") (Replacement "&lt;")
+  <<< replace (Pattern ">") (Replacement "&gt;")
+  <<< replace (Pattern "&") (Replacement "&amp;")
+  <<< replace (Pattern "\"") (Replacement "&quot;")
 
 foreign import withConsoleImpl
   :: forall a


### PR DESCRIPTION
Unless I'm missing some crucial context, there doesn't seem to be a reason why we need to use the FFI for `encode`.

Resolves #185.