### PR TITLE
Add missing spago build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ stack build
 
 # Install PureScript dependencies
 cd staging
-spago install
+spago build
 
 stack exec trypurescript 8081 $(spago sources)
 # should output that is is compiling the sources (first time)


### PR DESCRIPTION
An `output` directory is necessary and `spago build` creates this.
Note that `spago build` runs `spago install` first.

This doesn't fully fix development instructions, so leaving this as a draft.

Related to #183.

