### PR TITLE
Updates trypurescript to work with Halogen Affjax example

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -158,7 +158,7 @@
     }
 
     function setupIFrame($ctr, data) {
-      var $iframe = $('<iframe sandbox="allow-scripts" id="output-iframe" src="frame.html">');
+      var $iframe = $('<iframe sandbox="allow-scripts allow-forms" id="output-iframe" src="frame.html">');
 
       $ctr
         .empty()


### PR DESCRIPTION
Currently, the affjax example in Halogen does not work and returns the following response:

```
Blocked form submission to '' because the form's frame is sandboxed and the 'allow-forms' permission is not set.
```

I believe this fixes the issue, although I haven't tested it yet. Thanks!