### PR TITLE
Remove unused pragmas, imports, and definitions

### DIFF
--- a/server/Main.hs
+++ b/server/Main.hs
@@ -112,7 +112,10 @@ server externs initNamesEnv initEnv port = do
 
 getOpts :: Int -> Scotty.Options
 getOpts port = def
-  { settings = Warp.setHost "127.0.0.1" $ Warp.setPort port Warp.defaultSettings
+  { settings =
+      Warp.setHost "127.0.0.1"
+      $ Warp.setPort port
+      $ Warp.defaultSettings
   }
 
 lookupAllConstructors :: P.Environment -> P.SourceType -> [P.SourceType]

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -112,10 +112,7 @@ server externs initNamesEnv initEnv port = do
 
 getOpts :: Int -> Scotty.Options
 getOpts port = def
-  { settings =
-      Warp.setHost "127.0.0.1"
-      $ Warp.setPort port
-      $ Warp.defaultSettings
+  { settings = Warp.setHost "127.0.0.1" $ Warp.setPort port Warp.defaultSettings
   }
 
 lookupAllConstructors :: P.Environment -> P.SourceType -> [P.SourceType]


### PR DESCRIPTION
I finally got Try PureScript building on my machine and took some time to review the server code. While there, I noticed that there are a number of unused language pragmas, imports, and definitions in the file. This PR simply removes the dead code from the file (and removes one unnecessary dollar sign).