### PR TITLE
Use string body instead of Json in compile request

### DIFF
--- a/client/src/Try/API.purs
+++ b/client/src/Try/API.purs
@@ -21,7 +21,6 @@ import Affjax.StatusCode (StatusCode(..))
 import Control.Alt ((<|>))
 import Control.Monad.Except (ExceptT(..))
 import Data.Argonaut.Decode (class DecodeJson, decodeJson, (.:))
-import Data.Argonaut.Encode (encodeJson)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Data.Traversable (traverse)
@@ -107,4 +106,4 @@ compile endpoint code = ExceptT $ AX.post AXRF.json (endpoint <> "/compile") req
   Right { body } ->
     pure $ Right $ decodeJson body
   where
-  requestBody = Just $ AXRB.Json $ encodeJson code
+  requestBody = Just $ AXRB.string code


### PR DESCRIPTION
This fixes the CORS issue also noticed in #215, but we can merge this until folks have time to review that pull request.