### PR TITLE
Create valid symbolic link to output dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ cabal.sandbox.config
 *.chs.h
 *.lksh*
 bundle/
+client/public/js/output

--- a/README.md
+++ b/README.md
@@ -102,9 +102,7 @@ spago build
 # Note: due to the differences in the `ln` command between
 # MacOS (BSD ln) and Linux (GNU ln), the below code will work
 # on both operating systems:
-pushd ../client/public/js
-ln --symbolic ../../../staging/output/ .
-popd
+ln -s "$PWD/output" "$PWD/../client/public/js/output"
 
 # Then, start the server.
 #

--- a/README.md
+++ b/README.md
@@ -99,9 +99,6 @@ cd staging
 spago build
 
 # Ensure the compiled JavaScript is available to the client via symbolic link.
-# Note: due to the differences in the `ln` command between
-# MacOS (BSD ln) and Linux (GNU ln), the below code will work
-# on both operating systems:
 ln -s "$PWD/output" "$PWD/../client/public/js/output"
 
 # Then, start the server.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ cd staging
 spago build
 
 # Ensure the compiled JavaScript is available to the client
-ln -sr output ../client/public/js/output
+ln --symbolic --relative output ../client/public/js/output
 
 # Then, start the server.
 #

--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ cd staging
 spago build
 
 # Ensure the compiled JavaScript is available to the client
+#   The `ln` command works differently between MacOS and Linux.
+#   Use the command below that corresponds to your operating system:
+
+#   MacOS users
+ln --symbolic output ../client/public/js/output
+
+#   Linux users (requires the `--relative` flag)
 ln --symbolic --relative output ../client/public/js/output
 
 # Then, start the server.

--- a/README.md
+++ b/README.md
@@ -98,15 +98,13 @@ stack build
 cd staging
 spago build
 
-# Ensure the compiled JavaScript is available to the client
-#   The `ln` command works differently between MacOS and Linux.
-#   Use the command below that corresponds to your operating system:
-
-#   MacOS users
-ln --symbolic output ../client/public/js/output
-
-#   Linux users (requires the `--relative` flag)
-ln --symbolic --relative output ../client/public/js/output
+# Ensure the compiled JavaScript is available to the client via symbolic link.
+# Note: due to the differences in the `ln` command between
+# MacOS (BSD ln) and Linux (GNU ln), the below code will work
+# on both operating systems:
+pushd ../client/public/js
+ln --symbolic ../../../staging/output/ .
+popd
 
 # Then, start the server.
 #

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ cd staging
 spago build
 
 # Ensure the compiled JavaScript is available to the client
-ln -s output ../client/public/js/output
+ln -sr output ../client/public/js/output
 
 # Then, start the server.
 #


### PR DESCRIPTION
I was getting a 500 error in [#225 (comment)](https://github.com/purescript/trypurescript/pull/225#issuecomment-850724476) because the symbolic link created via `ln -s output ../client/public/js/output` was broken. 

Adding the `--relative` flag fixes the issue for me. I get the same view Thomas did in #225.