### PR TITLE
Fix status badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Try PureScript
 
-[![Build Status](https://api.travis-ci.org/purescript/trypurescript.svg?branch=master)](http://travis-ci.org/purescript/trypurescript)
+[![Build Status](https://github.com/purescript/trypurescript/workflows/CI/badge.svg?branch=master)](https://github.com/purescript/trypurescript/actions?query=workflow%3ACI+branch%3Amaster)
 
 [Try PureScript](https://try.purescript.org) is an online PureScript code editor for quickly experimenting with PureScript code snippets and ideas. It consists of a client and a server component, both of which live within this repository.
 


### PR DESCRIPTION
**Description of the change**

The README is still pointing at the Travis build status, but it should be pointing to the GitHub Actions CI workflow instead. (I think this can be left out of the CHANGELOG.)