### PR TITLE
Update caching for dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,7 @@ jobs:
           key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml.lock') }}-${{ hashFiles('trypurescript.cabal') }}
 
       - name: Build server code
-        run: |
-          stack --no-terminal -j1 build
+        run: stack --no-terminal -j1 build
 
       - name: Build server assets
         if: github.event_name == 'release'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,8 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
-          path: |
-            ~/.stack
-            .stack-work
-          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-stack
+          path: ~/.stack
+          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml.lock') }}-${{ hashFiles('trypurescript.cabal') }}
 
       - name: Build server code
         run: |


### PR DESCRIPTION
**Description of the change**

I noticed that caching doesn't appear to be working properly and is using the stack.yaml instead of stack.yaml.lock file. This PR updates the method.