### PR TITLE
Add const to requireRegex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 New features:
 
 Bugfixes:
+- Support use of JS `const` keyword in `requireRegex` (#237 by @ptrfrncsmrph)
 
 Other improvements:
 

--- a/client/src/Try/Loader.purs
+++ b/client/src/Try/Loader.purs
@@ -45,7 +45,7 @@ type Dependency =
   }
 
 requireRegex :: Regex
-requireRegex = unsafeRegex """^var\s+\S+\s*=\s*require\(["']([^"']*)["']\)""" noFlags
+requireRegex = unsafeRegex """^(?:const|var)\s+\S+\s*=\s*require\(["']([^"']*)["']\)""" noFlags
 
 dirname :: String -> String
 dirname path = fromMaybe "" do


### PR DESCRIPTION
**Description of the change**

Importing from `React.Basic.Hooks` is broken (see #236).
This seems to be because the `requireRegex` used by `parseDeps` only parses required modules using the `var` keyword, while recent updates to `React.Basic` modules switched from [`var` to `const`](https://github.com/lumihq/purescript-react-basic/commit/3e00fc48f5a0cab48f82f44296727902d54f6443#diff-700cdb9d6a9308b6f0d2162dde1ca07cd1c5c5fb9fa6344a4c4beaae92a69d0c).

This PR updates the `requireRegex` to match on
```js
const React = require("react")
```
in addition to the existing supported format
```js
var React = require("react")
```

<details><summary><strong>Before</strong></summary>
<img width="903" alt="Screen Shot 2021-07-04 at 12 57 44 PM" src="https://user-images.githubusercontent.com/26548438/124393870-9ec2c080-dcca-11eb-8ff5-6b427ecc6f17.png">
Note that the React "shim" (from `https://unpkg.com/react@16.13.1/umd/react.development.js`) is not included in *Sources*
</details>

<details><summary><strong>After</strong></summary>
<img width="903" alt="Screen Shot 2021-07-04 at 12 57 31 PM" src="https://user-images.githubusercontent.com/26548438/124393897-c023ac80-dcca-11eb-97d5-fcb0635598d6.png">
</details>

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0 by @)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
