### PR TITLE
Update to use PureScript 0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Bugfixes:
 
 Other improvements:
 
-- Update to build against PureScript 0.14.3 (#237 by @thomashoneyman)
+- Update to build against PureScript 0.14.3 (#238 by @thomashoneyman)
 
 ## [v2021-07-04.1](https://github.com/purescript/trypurescript/releases/tag/v2021-07-04.1) - 2021-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Bugfixes:
 
 Other improvements:
 
+- Update to build against PureScript 0.14.3 (#237 by @thomashoneyman)
+
 ## [v2021-07-04.1](https://github.com/purescript/trypurescript/releases/tag/v2021-07-04.1) - 2021-07-04
 
 Bugfixes:

--- a/README.md
+++ b/README.md
@@ -82,8 +82,6 @@ These steps should be performed whether you are working on the server, the clien
 # Clone into the repository
 git clone git@github.com:purescript/trypurescript.git
 cd trypurescript
-
-
 ```
 
 ### 2. Local compile server setup

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,12 +4,8 @@ packages:
   - "."
 
 extra-deps:
-  # purescript 0.14.3
-  - github: purescript/purescript
-    commit: b4c90a8bb6a1059f271f4211687192370fda81bc
-    subdirs:
-      - .
-      - lib/purescript-cst
+  - purescript-0.14.3
+  - purescript-cst-0.3.0.0
   - language-javascript-0.7.0.0
 
 flags:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,13 +1,19 @@
 resolver: lts-17.6
+
+packages:
+  - "."
+
+extra-deps:
+  # purescript 0.14.3
+  - github: purescript/purescript
+    commit: b4c90a8bb6a1059f271f4211687192370fda81bc
+    subdirs:
+      - .
+      - lib/purescript-cst
+  - language-javascript-0.7.0.0
+
 flags:
   aeson-pretty:
     lib-only: true
   these:
     assoc: false
-packages:
-- '.'
-extra-deps:
-- purescript-0.14.2
-- purescript-cst-0.2.0.0
-- happy-1.20.0
-- language-javascript-0.7.0.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,31 @@
 
 packages:
 - completed:
-    hackage: happy-1.19.9@sha256:f8c774230735a390c287b2980cfcd2703d24d8dde85a01ea721b7b4b4c82944f,4667
+    size: 711344
+    subdir: .
+    url: https://github.com/purescript/purescript/archive/b4c90a8bb6a1059f271f4211687192370fda81bc.tar.gz
+    name: purescript
+    version: 0.14.3
+    sha256: 66f8f95ccbaad4bf7cc92797548f6b6317ab438432605059772c0077ae6fd446
     pantry-tree:
-      size: 7980
-      sha256: 1f1d622f6e773e7a674da6364b755714c76c3fbb3c7a4e65deaf07242fc15211
+      size: 125562
+      sha256: 256c4cdca0253dea46fd656de273409648f617b25fbdcc742ae3b9595619d64c
   original:
-    hackage: happy-1.19.9
+    subdir: .
+    url: https://github.com/purescript/purescript/archive/b4c90a8bb6a1059f271f4211687192370fda81bc.tar.gz
+- completed:
+    size: 711344
+    subdir: lib/purescript-cst
+    url: https://github.com/purescript/purescript/archive/b4c90a8bb6a1059f271f4211687192370fda81bc.tar.gz
+    name: purescript-cst
+    version: 0.3.0.0
+    sha256: 66f8f95ccbaad4bf7cc92797548f6b6317ab438432605059772c0077ae6fd446
+    pantry-tree:
+      size: 3018
+      sha256: 55486cc019d034e2972a19e745727b33c9b5259d3ac2c0421651ce273d1096f3
+  original:
+    subdir: lib/purescript-cst
+    url: https://github.com/purescript/purescript/archive/b4c90a8bb6a1059f271f4211687192370fda81bc.tar.gz
 - completed:
     hackage: language-javascript-0.7.0.0@sha256:3eab0262b8ac5621936a4beab6a0f97d0e00a63455a8b0e3ac1547b4088dae7d,3898
     pantry-tree:
@@ -18,30 +37,9 @@ packages:
       sha256: b0f28d836cb3fbde203fd7318a896c3a20acd8653a905e1950ae2d9a64bccebf
   original:
     hackage: language-javascript-0.7.0.0
-- completed:
-    hackage: network-3.0.1.1@sha256:1a251b790ea98b6f7433f677958f921950780ba6f143d61ba8c0e3f7a9879097,4074
-    pantry-tree:
-      size: 3296
-      sha256: 78e378780c998faaf4e32a16b98880220f502d8ef005f24d7ee0c99fb50636e6
-  original:
-    hackage: network-3.0.1.1
-- completed:
-    hackage: these-1.0.1@sha256:7ff0f309978604015d978fb155ac4dc10a98e3d70a99aa2be8f755eb0cca4324,3191
-    pantry-tree:
-      size: 351
-      sha256: 3257ef64424e9a07e2ae750eff7affcd459811c4669cb67a5e4f43ab833c5aba
-  original:
-    hackage: these-1.0.1
-- completed:
-    hackage: semialign-1@sha256:f11b3d8d0f31a3556061ec0fb515575646d162f12c5b25a0f07c92679db7d862,2433
-    pantry-tree:
-      size: 466
-      sha256: e67b833b94b7fa23afbf7088833a38596cf35a2b93635604dd9e49d0389360fe
-  original:
-    hackage: semialign-1
 snapshots:
 - completed:
-    size: 499889
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/26.yaml
-    sha256: ecb02ee16829df8d7219e7d7fe6c310819820bf335b0b9534bce84d3ea896684
-  original: lts-13.26
+    size: 565712
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/6.yaml
+    sha256: 4e5e581a709c88e3fe26a9ce8bf331435729bead762fb5c190064c6c5bb1b835
+  original: lts-17.6

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,31 +5,19 @@
 
 packages:
 - completed:
-    size: 711344
-    subdir: .
-    url: https://github.com/purescript/purescript/archive/b4c90a8bb6a1059f271f4211687192370fda81bc.tar.gz
-    name: purescript
-    version: 0.14.3
-    sha256: 66f8f95ccbaad4bf7cc92797548f6b6317ab438432605059772c0077ae6fd446
+    hackage: purescript-0.14.3@sha256:4b75604e86c335711e1b1f1f73ef381108d047c9277df1cdc71922ec7da7c181,18623
     pantry-tree:
-      size: 125562
-      sha256: 256c4cdca0253dea46fd656de273409648f617b25fbdcc742ae3b9595619d64c
+      size: 132222
+      sha256: e3957c9d2c96434fcf5e8f310b34f4ea696cc8e5f63e60958eae5c6e31aba4c6
   original:
-    subdir: .
-    url: https://github.com/purescript/purescript/archive/b4c90a8bb6a1059f271f4211687192370fda81bc.tar.gz
+    hackage: purescript-0.14.3
 - completed:
-    size: 711344
-    subdir: lib/purescript-cst
-    url: https://github.com/purescript/purescript/archive/b4c90a8bb6a1059f271f4211687192370fda81bc.tar.gz
-    name: purescript-cst
-    version: 0.3.0.0
-    sha256: 66f8f95ccbaad4bf7cc92797548f6b6317ab438432605059772c0077ae6fd446
+    hackage: purescript-cst-0.3.0.0@sha256:369317d52737c4fa8c74a875283ed6cc0ef68e7c64db13d6e5bb7a7f72b76572,3861
     pantry-tree:
       size: 3018
-      sha256: 55486cc019d034e2972a19e745727b33c9b5259d3ac2c0421651ce273d1096f3
+      sha256: 38f94bcc121068215c6082bab39b6c555cadd3b88e786740c394a5c4b98c4100
   original:
-    subdir: lib/purescript-cst
-    url: https://github.com/purescript/purescript/archive/b4c90a8bb6a1059f271f4211687192370fda81bc.tar.gz
+    hackage: purescript-cst-0.3.0.0
 - completed:
     hackage: language-javascript-0.7.0.0@sha256:3eab0262b8ac5621936a4beab6a0f97d0e00a63455a8b0e3ac1547b4088dae7d,3898
     pantry-tree:


### PR DESCRIPTION
**Description of the change**

This PR updates Try PureScript to use the 0.14.3 compiler. I opted to update Try PureScript quickly because of issues like https://github.com/purescript/purescript/issues/4110, which are present on current Try PureScript:

<img width="793" alt="Screen Shot 2021-07-06 at 11 29 10 PM" src="https://user-images.githubusercontent.com/10245104/124711075-772e4c80-deb2-11eb-9390-1386a12611d3.png">

...but not in this PR:

<img width="781" alt="Screen Shot 2021-07-06 at 11 29 28 PM" src="https://user-images.githubusercontent.com/10245104/124711099-7eedf100-deb2-11eb-9572-931c96d9f9ad.png">

This PR uses the same commit for PureScript as https://github.com/purescript/pursuit/pull/436.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0 by @)")
- [x] Linked any existing issues or proposals that this pull request should close
- ~Updated or added relevant documentation~
- ~Added a test for the contribution (if applicable)~
