### PR TITLE
Fix encode only replacing first occurrences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 New features:
 
 Bugfixes:
+- Fixed `encode` not replacing all instances of special characters (#254 by @jy14898)
 
 ## [v2021-08-25.1](https://github.com/purescript/trypurescript/releases/tag/v2021-08-25.1) - 2021-08-25
 

--- a/staging/src/TryPureScript.purs
+++ b/staging/src/TryPureScript.purs
@@ -20,7 +20,7 @@ module TryPureScript
 import Prelude
 import Data.Foldable (class Foldable, foldMap)
 import Data.String (joinWith)
-import Data.String.Common (replace)
+import Data.String.Common (replaceAll)
 import Data.String.Pattern (Pattern(..), Replacement(..))
 import Effect (Effect)
 
@@ -28,10 +28,10 @@ foreign import setInnerHTML :: String -> Effect Unit
 
 encode :: String -> String
 encode =
-  replace (Pattern "<") (Replacement "&lt;")
-  <<< replace (Pattern ">") (Replacement "&gt;")
-  <<< replace (Pattern "&") (Replacement "&amp;")
-  <<< replace (Pattern "\"") (Replacement "&quot;")
+  replaceAll (Pattern "<") (Replacement "&lt;")
+  <<< replaceAll (Pattern ">") (Replacement "&gt;")
+  <<< replaceAll (Pattern "&") (Replacement "&amp;")
+  <<< replaceAll (Pattern "\"") (Replacement "&quot;")
 
 foreign import withConsoleImpl
   :: forall a


### PR DESCRIPTION
Fixes `"text try.purescript.org?github=/<owner>/<repo>/<branch or tag>/<file>.purs"` being shown as `try.purescript.org?github=/<owner>///.purs` in the main example

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0 by @)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
