### PR TITLE
Adds longer loading screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ New features:
 
 Bugfixes:
 - Fixed `encode` not replacing all instances of special characters (#254 by @jy14898)
+- Fixed up-to-five-second hangs between the loading icon disappearing and the content rendering (#256 @mikesol)
 
 ## [v2021-08-25.1](https://github.com/purescript/trypurescript/releases/tag/v2021-08-25.1) - 2021-08-25
 

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -29,15 +29,14 @@
         $ctr.remove()
       }
 
-      function setupIFrame(data) {
+      function setupIFrame(data, loadCb, failCb) {
         var $ctr = $("#column2");
         var $iframe = $(
           '<iframe sandbox="allow-scripts allow-forms" id="output-iframe" src="frame.html">'
         );
-
         $ctr.empty().append($iframe);
-
         var tries = 0;
+        
         var sendSources = setInterval(function () {
           // Stop after 10 seconds
           if (tries >= 100) {
@@ -47,7 +46,9 @@
           var iframe = $iframe.get(0).contentWindow;
           if (iframe) {
             iframe.postMessage(data, "*");
+            loadCb();
           } else {
+            failCb();
             console.warn("Frame is not available");
           }
         }, 100);


### PR DESCRIPTION
**Description of the change**

Keeps the loader up longer, lowering blank-screen time to less than 50ms.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0 by @)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
