### PR TITLE
Display FFI errors to user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Bugfixes:
 Other improvements:
 
 - Use `replaceState` for setting query params (#266 by @ptrfrncsmrph)
+- Display missing FFI dependency error message to user (#268 by @ptrfrncsmrph)
 
 ## [v2021-11-30.1](https://github.com/purescript/trypurescript/releases/tag/v2021-11-11.1)
 

--- a/client/public/css/index.css
+++ b/client/public/css/index.css
@@ -221,6 +221,12 @@ pre code {
   background: none;
   border: 0;
   margin: 0;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  white-space: -moz-pre-wrap;
+  white-space: -pre-wrap;
+  white-space: -o-pre-wrap;
+  word-wrap: break-word;
 }
 
 iframe {

--- a/client/src/Try/Loader.purs
+++ b/client/src/Try/Loader.purs
@@ -7,7 +7,7 @@ module Try.Loader
 import Prelude
 
 import Control.Bind (bindFlipped)
-import Control.Monad.Except (ExceptT)
+import Control.Monad.Except (ExceptT, throwError)
 import Control.Parallel (parTraverse)
 import Data.Array as Array
 import Data.Array.NonEmpty as NonEmpty
@@ -112,7 +112,7 @@ makeLoader rootPath = Loader (go Object.empty <<< parseDeps "<file>")
                   deps = { name: _, path: Nothing } <$> shim.deps
                 pure { name, path, deps, src }
               Nothing ->
-                pure { name, path, deps: [], src: ffiDep name }
+                throwError ("FFI dependency not provided: " <> name)
         liftEffect $ putModule name mod
         pure mod
 
@@ -130,6 +130,3 @@ makeLoader rootPath = Loader (go Object.empty <<< parseDeps "<file>")
       # bindFlipped _.deps
       # Array.nubBy (comparing _.name)
       # go ms'
-
-ffiDep :: String -> JS
-ffiDep name = JS $ "throw new Error('FFI dependency not provided: " <> name <> "');"


### PR DESCRIPTION
**Description of the change**

Fixes https://github.com/purescript/trypurescript/issues/265

These are minimal changes to render an error message in the case of a missing FFI dependency. We are displaying the message in the right pane (using the same `renderPlainText` function that's used for displaying the JS output for example) as well as throwing an error so that it's visible in the browser console. If there are multiple missing dependencies, only the first will be rendered to the user.

I looked into accumulating an array of misses using `Data.Validation.Semigroup` in https://github.com/purescript/trypurescript/pull/267, but I don't know that the added complexity was justified, since it seems like there would rarely be more than a single missing FFI dep.

### Screenshots

<details><summary><strong>Single missing FFI dependency</strong></summary>

Before
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/26548438/152660660-91d41c72-7e80-42b3-89fc-2cb61bc629a4.png">

After
<img width="1440" alt="Screen Shot 2022-02-05 at 4 24 15 PM" src="https://user-images.githubusercontent.com/26548438/152660324-3ba280c7-efb1-4828-b5d3-09846458499f.png">

</details>

<details><summary><strong>Multiple missing FFI dependencies</strong></summary>
Same error messages as single-missing, even though <code>puppeteer</code> is another missing dependency here.

Before
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/26548438/152660619-34646dc4-35ad-4eaf-b18e-6f5037f62815.png">

After
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/26548438/152660571-0bc99b2e-fa58-4fe6-9f7e-a6ee70406ae1.png">

</details>


<details><summary><strong>Server error</strong></summary>
Simulated by setting <code>Try.Config.loaderUrl</code> to a non-existent URL

Before (not sure why this isn't showing "Unable to parse the response from the server.")
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/26548438/152660765-dcd31edf-87a9-40ce-a706-e76be965aed4.png">

After
<img width="1440" alt="Screen Shot 2022-02-05 at 4 31 33 PM" src="https://user-images.githubusercontent.com/26548438/152660389-25063b6a-025c-4d24-8864-307988a69f68.png">


</details>

<details><summary><strong>Successfully compiled code</strong></summary>
I added word-wrap to the <code>code</code> tag rendered by <code>renderPlainText</code> to avoid horizontal scrolling for error messages, which also affects how the compiled JS looks (maybe not for the better 🤷 ) 

Before
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/26548438/152660861-10cf5ce5-7494-4c1b-a629-d0c7a47b9c08.png">

After
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/26548438/152660445-3f975809-5cdd-4bf5-8cb5-d4279e9210c9.png">

</details>

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0 by @)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
