### PR TITLE
Fix double main call by updating es-module-shims to 1.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 New features:
 
 Bugfixes:
+- Stop double `main` invocation by updating `es-module-shims` to 1.5.6 (#279 by @JordanMartinez)
 
 Other improvements:
 

--- a/client/public/frame.html
+++ b/client/public/frame.html
@@ -41,7 +41,7 @@
   </script>
 
   <!-- ES Module Shims: Import maps polyfill for modules browsers without import maps support (all except Chrome 89+) -->
-  <script async src="https://ga.jspm.io/npm:es-module-shims@1.5.5/dist/es-module-shims.js" integrity="sha384-Zt+0efULC2q2dftjz0uNzXeTpPVuSLLekXQv9HoRuigkAyLPaUFvPVpYYhu2Xc/t" crossorigin="anonymous"></script>
+  <script async src="https://ga.jspm.io/npm:es-module-shims@1.5.6/dist/es-module-shims.js" integrity="sha384-Zi3OSEiS8YnN0yIdnkInyBlzXCGA18AMnQuPb+T1hXvE4DIDhGIp2QIBZcm4WNIU" crossorigin="anonymous"></script>
 
   <script src="js/frame.js"></script>
 </head>


### PR DESCRIPTION
**Description of the change**

Currently, try.purescript.org will run the `main` function twice when one uses `TP.render =<< TP.withConsole <<< log "foo"`

Updating `es-module-shims` to the next version fixes this on Firefox  when I test the client against the production server.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0 by @)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
