### PR TITLE
Use div-root; fix examples' warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Fixes compiler warnings in examples (#286 by @JordanMartinez)
+- Support cookbook repo UI recipes by adding element to `frame.html` (#286 by @JordanMartinez)
 
 ## [v2022-07-12.1](https://github.com/purescript/trypurescript/releases/tag/v2022-07-12.1)
 

--- a/client/examples/ADTs.purs
+++ b/client/examples/ADTs.purs
@@ -19,5 +19,6 @@ derive instance ordName :: Ord Name
 phoneBook :: Map Name String
 phoneBook = singleton (Name "John" "Smith") "555-555-1234"
 
+main :: Effect Unit
 main = render =<< withConsole do
   logShow (lookup (Name "John" "Smith") phoneBook)

--- a/client/examples/DoNotation.purs
+++ b/client/examples/DoNotation.purs
@@ -5,7 +5,7 @@ import Control.MonadPlus (guard)
 import Effect.Console (logShow)
 import Data.Array ((..))
 import Data.Foldable (for_)
-import TryPureScript
+import TryPureScript (render, withConsole)
 
 -- Find Pythagorean triples using an array comprehension.
 triples :: Int -> Array (Array Int)
@@ -16,5 +16,6 @@ triples n = do
   guard $ x * x + y * y == z * z
   pure [x, y, z]
 
+main :: Effect Unit
 main = render =<< withConsole do
   for_ (triples 20) logShow

--- a/client/examples/Generic.purs
+++ b/client/examples/Generic.purs
@@ -45,6 +45,7 @@ instance eqPerson :: Eq Person where
 instance ordPerson :: Ord Person where
   compare = genericCompare
 
+main :: Effect Unit
 main = render =<< withConsole do
   logShow $ Person
     { first: "John"

--- a/client/examples/Loops.purs
+++ b/client/examples/Loops.purs
@@ -7,6 +7,7 @@ import Data.Array ((..))
 import Data.Foldable (for_)
 import TryPureScript (render, withConsole)
 
+main :: Effect Unit
 main = render =<< withConsole do
   for_ (10 .. 1) \n -> log (show n <> "...")
   log "Lift off!"

--- a/client/examples/Operators.purs
+++ b/client/examples/Operators.purs
@@ -16,5 +16,6 @@ infixl 5 subdirectory as </>
 filepath :: FilePath
 filepath = "usr" </> "local" </> "bin"
 
+main :: Effect Unit
 main = render =<< withConsole do
   log filepath

--- a/client/examples/QuickCheck.purs
+++ b/client/examples/QuickCheck.purs
@@ -5,6 +5,7 @@ import Data.Array (sort)
 import Test.QuickCheck (quickCheck, (===))
 import TryPureScript (render, withConsole, h1, h2, p, text)
 
+main :: Effect Unit
 main = do
   render $ h1 $ text "QuickCheck"
   render $ p $ text """QuickCheck is a Haskell library which allows us to assert properties

--- a/client/examples/Records.purs
+++ b/client/examples/Records.purs
@@ -5,10 +5,12 @@ import Effect.Console (log)
 import TryPureScript (render, withConsole)
 
 -- We can write functions which require certain record labels...
+showPerson :: forall r. { firstName :: String, lastName :: String | r } -> String
 showPerson o = o.lastName <> ", " <> o.firstName
 
 -- ... but we are free to call those functions with any
 -- additional arguments, such as "age" here.
+main :: Effect Unit
 main = render =<< withConsole do
   log $ showPerson
     { firstName: "John"

--- a/client/examples/Recursion.purs
+++ b/client/examples/Recursion.purs
@@ -12,6 +12,7 @@ isEven :: Int -> Boolean
 isEven 0 = true
 isEven n = isOdd (n - 1)
 
+main :: Effect Unit
 main = render =<< withConsole do
   logShow $ isEven 1000
   logShow $ isEven 1001

--- a/client/examples/TypeClasses.purs
+++ b/client/examples/TypeClasses.purs
@@ -39,6 +39,7 @@ printf = printfWith ""
 debug :: String -> Int -> String -> String
 debug uri status msg = printf "[" uri "] " status ": " msg
 
+main :: Effect Unit
 main = render =<< withConsole do
   log $ debug "http://www.purescript.org" 200 "OK"
   log $ debug "http://bad.purescript.org" 404 "Not found"

--- a/client/public/frame.html
+++ b/client/public/frame.html
@@ -47,5 +47,6 @@
 </head>
 <body>
   <main id="main"></main>
+  <div id="root"></div>
 </body>
 </html>


### PR DESCRIPTION
**Description of the change**

Fixes #283. Also allows updates the `frame.html` file to include a `<div id="root"></div>`. See https://github.com/JordanMartinez/purescript-cookbook/issues/198

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0 by @)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
