### PR TITLE
Fix NPM shim resolver on Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 - Fix `Reference Error: main is not defined` bug: (#288 by @JordanMartinez)
 - Fix NPM dependency shims on Firefox 100+ (#289 by @JordanMartinez)
+- Fix import maps for React deps by using development version (#289 by @JordanMartinez)
 
 Other improvements:
 - Update `es-module-shims` to 1.5.9 (#289 by @JordanMartinez)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ New features:
 
 Bugfixes:
 - Fix `Reference Error: main is not defined` bug: (#288 by @JordanMartinez)
+- Fix NPM dependency shims on Firefox 100+ (#289 by @JordanMartinez)
 
 Other improvements:
+- Update `es-module-shims` to 1.5.9 (#289 by @JordanMartinez)
 
 ## [v2022-07-15.1](https://github.com/purescript/trypurescript/releases/tag/v2022-07-15.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ New features:
 Bugfixes:
 - Fix `Reference Error: main is not defined` bug: (#288 by @JordanMartinez)
 - Fix NPM dependency shims on Firefox 100+ (#289 by @JordanMartinez)
-- Fix import maps for React deps by using development version (#289 by @JordanMartinez)
+- Fix import maps for React deps by bumping version to 17.0.2 (#289 by @JordanMartinez)
 
 Other improvements:
 - Update `es-module-shims` to 1.5.9 (#289 by @JordanMartinez)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -52,7 +52,6 @@ Update the package set by doing the following:
         - If it exists but doesn't exist in that CDN, you can try another one or [open an issue on `jspm/project`](https://github.com/jspm/project#issue-queue-for-the-jspm-cdn)
     - Update the version to the one you need once added
     - If needed, include other files from that dependency
-    - Ensure the Development mode is used, not Production. Production uses minified JS.
     - Copy and paste the content into the `client/public/frame.html` file
     - Ensure `es-module-shims` has version `1.5.9` or greater.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -52,8 +52,9 @@ Update the package set by doing the following:
         - If it exists but doesn't exist in that CDN, you can try another one or [open an issue on `jspm/project`](https://github.com/jspm/project#issue-queue-for-the-jspm-cdn)
     - Update the version to the one you need once added
     - If needed, include other files from that dependency
+    - Ensure the Development mode is used, not Production. Production uses minified JS.
     - Copy and paste the content into the `client/public/frame.html` file
-    - Ensure `es-module-shims` has version `1.5.5` or greater.
+    - Ensure `es-module-shims` has version `1.5.9` or greater.
 
 6. If `es-module-shims` releases a new version, you can calculate its SHA-384 via
 

--- a/client/public/frame.html
+++ b/client/public/frame.html
@@ -41,7 +41,7 @@
   </script>
 
   <!-- ES Module Shims: Import maps polyfill for modules browsers without import maps support (all except Chrome 89+) -->
-  <script async src="https://ga.jspm.io/npm:es-module-shims@1.5.6/dist/es-module-shims.js" integrity="sha384-Zi3OSEiS8YnN0yIdnkInyBlzXCGA18AMnQuPb+T1hXvE4DIDhGIp2QIBZcm4WNIU" crossorigin="anonymous"></script>
+  <script async src="https://ga.jspm.io/npm:es-module-shims@1.5.9/dist/es-module-shims.js" integrity="sha384-O6YhhDNmwzHXz9VDaEaEtY9rnzCF5Fy+yoxD6StrNyhjwyBrYYOjZkbFRt9zcoGx" crossorigin="anonymous"></script>
 
   <script src="js/frame.js"></script>
 </head>

--- a/client/public/frame.html
+++ b/client/public/frame.html
@@ -18,23 +18,24 @@
   </script>
   <!--
     JSPM Generator Import Map
-    Edit URL: https://generator.jspm.io/#Y2NnYGCzD80rySzJSU1hSMpM183MK0lNTy1yMNQz0zM1ZEhJTc7MTczRyyp2MDTQM9YzZChKTUwu0U3Jz3UwNNMzxCqiX5xaVJZaBJGAKystzUxxsACaYQQAoBlP83cA
+    Edit URL: https://generator.jspm.io/#Y2VhYGCzD80rySzJSU1hSMpM183MK0lNTy1yMNQz0zM1ZEhJTc7MTczRyyp2MDTQM9YzZChKTUwu0U3Jz3UwNNMzxCqiX5xaVJZaBJGAKystzUxxsACaYQQAQSdSGncA
   -->
   <script type="importmap">
   {
     "imports": {
       "big-integer": "https://ga.jspm.io/npm:big-integer@1.6.51/BigInteger.js",
       "decimal.js": "https://ga.jspm.io/npm:decimal.js@10.3.1/decimal.js",
-      "react": "https://ga.jspm.io/npm:react@16.13.1/index.js",
-      "react-dom": "https://ga.jspm.io/npm:react-dom@16.13.1/index.js",
-      "react-dom/server": "https://ga.jspm.io/npm:react-dom@16.13.1/server.browser.js",
+      "react": "https://ga.jspm.io/npm:react@16.13.1/dev.index.js",
+      "react-dom": "https://ga.jspm.io/npm:react-dom@16.13.1/dev.index.js",
+      "react-dom/server": "https://ga.jspm.io/npm:react-dom@16.13.1/dev.server.browser.js",
       "uuid": "https://ga.jspm.io/npm:uuid@8.3.2/dist/esm-browser/index.js"
     },
     "scopes": {
       "https://ga.jspm.io/": {
         "object-assign": "https://ga.jspm.io/npm:object-assign@4.1.1/index.js",
-        "react": "https://ga.jspm.io/npm:react@16.14.0/index.js",
-        "scheduler": "https://ga.jspm.io/npm:scheduler@0.19.1/index.js"
+        "prop-types/checkPropTypes": "https://ga.jspm.io/npm:prop-types@15.8.1/dev.checkPropTypes.js",
+        "scheduler": "https://ga.jspm.io/npm:scheduler@0.19.1/dev.index.js",
+        "scheduler/tracing": "https://ga.jspm.io/npm:scheduler@0.19.1/dev.tracing.js"
       }
     }
   }

--- a/client/public/frame.html
+++ b/client/public/frame.html
@@ -18,24 +18,22 @@
   </script>
   <!--
     JSPM Generator Import Map
-    Edit URL: https://generator.jspm.io/#Y2VhYGCzD80rySzJSU1hSMpM183MK0lNTy1yMNQz0zM1ZEhJTc7MTczRyyp2MDTQM9YzZChKTUwu0U3Jz3UwNNMzxCqiX5xaVJZaBJGAKystzUxxsACaYQQAQSdSGncA
+    Edit URL: https://generator.jspm.io/#Y2NhYGCzD80rySzJSU1hSMpM183MK0lNTy1yMNQz0zM1ZEhJTc7MTczRyyp2MDTQM9YzZChKTUwu0U3Jz3UwNNcz0DPCENAvTi0qSy2CiMMUlZZmpjhYAA0wAgA6XlZ2dAA
   -->
   <script type="importmap">
   {
     "imports": {
       "big-integer": "https://ga.jspm.io/npm:big-integer@1.6.51/BigInteger.js",
       "decimal.js": "https://ga.jspm.io/npm:decimal.js@10.3.1/decimal.js",
-      "react": "https://ga.jspm.io/npm:react@16.13.1/dev.index.js",
-      "react-dom": "https://ga.jspm.io/npm:react-dom@16.13.1/dev.index.js",
-      "react-dom/server": "https://ga.jspm.io/npm:react-dom@16.13.1/dev.server.browser.js",
+      "react": "https://ga.jspm.io/npm:react@17.0.2/index.js",
+      "react-dom": "https://ga.jspm.io/npm:react-dom@17.0.2/index.js",
+      "react-dom/server": "https://ga.jspm.io/npm:react-dom@17.0.2/server.browser.js",
       "uuid": "https://ga.jspm.io/npm:uuid@8.3.2/dist/esm-browser/index.js"
     },
     "scopes": {
       "https://ga.jspm.io/": {
         "object-assign": "https://ga.jspm.io/npm:object-assign@4.1.1/index.js",
-        "prop-types/checkPropTypes": "https://ga.jspm.io/npm:prop-types@15.8.1/dev.checkPropTypes.js",
-        "scheduler": "https://ga.jspm.io/npm:scheduler@0.19.1/dev.index.js",
-        "scheduler/tracing": "https://ga.jspm.io/npm:scheduler@0.19.1/dev.tracing.js"
+        "scheduler": "https://ga.jspm.io/npm:scheduler@0.20.2/index.js"
       }
     }
   }


### PR DESCRIPTION
**Description of the change**

Fixes #289. However, trying to run the React examples from the cookbook get a weird error even with this fix:
- Works: [`HelloReactHooks`](https://github.com/JordanMartinez/purescript-cookbook/blob/master/recipes/HelloReactHooks/src/Main.purs)
- Fails: [`ButtonsReactHooks`](https://github.com/JordanMartinez/purescript-cookbook/blob/master/recipes/ButtonsReactHooks/src/Main.purs)

![2022-07-16_11-34](https://user-images.githubusercontent.com/8413037/179363854-d6a9bd65-96b4-448c-af3b-2b208dcc38cd.png)


---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0 by @)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
