### PR TITLE
Show compiled JS based on query params only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 New features:
 
 Bugfixes:
+- Stop loading hang when using query params to show compiled JS output (#296 by @JordanMartinez)
 
 Other improvements:
 

--- a/client/src/Try/Container.purs
+++ b/client/src/Try/Container.purs
@@ -183,8 +183,9 @@ component = H.mkComponent
 
         Right res@(Right (CompileSuccess { js, warnings })) -> do
           { settings } <- H.get
-          if settings.showJs then
+          if settings.showJs then do
             H.liftEffect teardownIFrame
+            H.modify_ _ { compiled = Just res }
           else do
             for_ warnings \warnings_ -> do
               let anns = Array.mapMaybe (toAnnotation MarkerWarning) warnings_


### PR DESCRIPTION
**Description of the change**

I noticed that using the `view=output&js=true` query params (e.g. https://try.purescript.org/?view=output&js=true) don't show the compiled JavaScript but rather shows a loading screen for forever. This is annoying because I can't just show others what PureScript's output looks like when they're curious. 

This fixes that.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0 by @)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
