### PR TITLE
es-module-shims 1.5.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Update `es-module-shims` to 1.5.12 (#298 by @andys8)
 
 ## [v2022-08-12.1](https://github.com/purescript/trypurescript/releases/tag/v2022-08-12.1)
 

--- a/client/public/frame.html
+++ b/client/public/frame.html
@@ -30,6 +30,8 @@
   </script>
 
   <!-- ES Module Shims: Import maps polyfill for modules browsers without import maps support (all except Chrome 89+) -->
+  <!-- While 1.5.12 is not the latest release (1.5.16) and still sometimes shows an error (head on null) it is currently the best option -->
+  <!-- See https://github.com/purescript/trypurescript/pull/297#issuecomment-1214194277 -->
   <script async src="https://ga.jspm.io/npm:es-module-shims@1.5.12/dist/es-module-shims.js" integrity="sha384-KpzeqocuAuGQvuaqG8NBwER/6UR/rFGoff/DdvgKT1OBZsR/GyQXTn6hrC5J+K2B" crossorigin="anonymous"></script>
 
   <script src="js/frame.js"></script>

--- a/client/public/frame.html
+++ b/client/public/frame.html
@@ -5,11 +5,6 @@
   <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <meta content="utf-8" http-equiv="encoding">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <script>
-    window.esmsInitOptions = {
-      shimMode: true,
-    };
-  </script>
   <!--
     JSPM Generator Import Map
     Edit URL: https://generator.jspm.io/#ZcxBDkAwEEDRWQinMQwhlr2EA9BOZKQqqamtq5OIle1L/s8zgOIag4p6djDLUkpQXjgawh47AsdWtsnjehiqsUWCyJPV0u2boQEbrH9QWS8c9O8Hx5Pj61+ckjgzPOPmBszFaRmMAA
@@ -35,7 +30,7 @@
   </script>
 
   <!-- ES Module Shims: Import maps polyfill for modules browsers without import maps support (all except Chrome 89+) -->
-  <script async src="https://ga.jspm.io/npm:es-module-shims@1.5.9/dist/es-module-shims.js" integrity="sha384-O6YhhDNmwzHXz9VDaEaEtY9rnzCF5Fy+yoxD6StrNyhjwyBrYYOjZkbFRt9zcoGx" crossorigin="anonymous"></script>
+  <script async src="https://ga.jspm.io/npm:es-module-shims@1.5.12/dist/es-module-shims.js" integrity="sha384-KpzeqocuAuGQvuaqG8NBwER/6UR/rFGoff/DdvgKT1OBZsR/GyQXTn6hrC5J+K2B" crossorigin="anonymous"></script>
 
   <script src="js/frame.js"></script>
 </head>


### PR DESCRIPTION
Version 1.5.12 is currently - including the latest bug fix 1.5.15 - the best version for the project where the examples work in all tested browsers.

See these discussions for more details:

* <https://github.com/purescript/trypurescript/pull/297#issuecomment-1214194277>
* <https://github.com/guybedford/es-module-shims/issues/324#issuecomment-1214452714>