### PR TITLE
Fix PR reference in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ Other improvements:
 ## [v2023-07-18.1](https://github.com/purescript/trypurescript/releases/tag/v2023-07-18.1)
 
 Other improvements:
-- Bump PureScript to `0.15.10` (#306 by @JordanMartinez)
-- Update to latest package set (#306 by @JordanMartinez)
+- Bump PureScript to `0.15.10` (#310 by @JordanMartinez)
+- Update to latest package set (#310 by @JordanMartinez)
 
 ## [v2023-03-06.1](https://github.com/purescript/trypurescript/releases/tag/v2023-03-06.1)
 


### PR DESCRIPTION
**Description of the change**

The changelog referenced #306 as the PR for updating to 0.15.10, but it was actually #310.